### PR TITLE
handle the empty compare session case

### DIFF
--- a/app/controllers/spree/products_controller.rb
+++ b/app/controllers/spree/products_controller.rb
@@ -26,7 +26,11 @@ module Spree
     end
 
     def compare
-      @products = [Product.friendly.find(session[:compare].first)]
+      if session[:compare]
+        @products = [Product.friendly.find(session[:compare].first)]
+      else
+        @products = []
+      end
     end
 
     def add_to_compare


### PR DESCRIPTION
Fixes an error when comparing with no items in the comparison set.